### PR TITLE
Fix Windows template build scripts

### DIFF
--- a/scripts/build-assets.mjs
+++ b/scripts/build-assets.mjs
@@ -44,7 +44,7 @@ function buildBundles() {
 
   const jsBundle = jsFiles
     .map(file => readFileSync(file, 'utf8')
-      .replace(/^import .+;\n/gm, '')
+      .replace(/^import .+;\r?\n/gm, '')
       .replace(/^export class /gm, 'class ')
       .trim())
     .join('\n\n');

--- a/scripts/check-local-paths.mjs
+++ b/scripts/check-local-paths.mjs
@@ -22,7 +22,7 @@ function extension(path) {
 }
 
 function scanFile(path) {
-  if (ignoredFiles.has(path)) return;
+  if (ignoredFiles.has(path.replaceAll('\\', '/'))) return;
   if (ignoredExtensions.has(extension(path))) return;
 
   const buffer = readFileSync(path);


### PR DESCRIPTION
## Summary
- Strip JS imports when source files use either LF or CRLF line endings
- Normalize Windows path separators before checking ignored local-path scanner files

## Validation
- npm.cmd run build
- npm.cmd run validate